### PR TITLE
Fix of `gauss_2d_large(seed=63)` -> `NaN`

### DIFF
--- a/kcsd/validation/csd_profile.py
+++ b/kcsd/validation/csd_profile.py
@@ -33,7 +33,7 @@ def repeatUntilValid(f):
                 return result
 
             rstate = np.random.RandomState(seed)
-            seed = rstate.randint(2**32 - 1)
+            seed = rstate.randint(2**32)
 
     # Python 2.7 walkarround necessary for test purposes
     if not hasattr(wrapper, '__wrapped__'):

--- a/kcsd/validation/csd_profile.py
+++ b/kcsd/validation/csd_profile.py
@@ -52,7 +52,6 @@ def seedSequence(seed):
         yield seed
 
         previous.add(seed)
-        rstate.seed(seed)
         while seed in previous:
             seed = rstate.randint(2 ** 32)
 

--- a/kcsd/validation/csd_profile.py
+++ b/kcsd/validation/csd_profile.py
@@ -27,13 +27,17 @@ def repeatUntilValid(f):
     """
     @wraps(f)
     def wrapper(arg, seed=0):
+        seeds = set()
         while True:
+            seeds.add(seed)
+
             result = f(arg, seed)
             if isfinite(result).all():
                 return result
 
             rstate = np.random.RandomState(seed)
-            seed = rstate.randint(2**32)
+            while seed in seeds:
+                seed = rstate.randint(2 ** 32)
 
     # Python 2.7 walkarround necessary for test purposes
     if not hasattr(wrapper, '__wrapped__'):

--- a/kcsd/validation/csd_profile.py
+++ b/kcsd/validation/csd_profile.py
@@ -27,23 +27,34 @@ def repeatUntilValid(f):
     """
     @wraps(f)
     def wrapper(arg, seed=0):
-        seeds = set()
-        while True:
-            seeds.add(seed)
-
+        for seed in seedSequence(seed):
             result = f(arg, seed)
             if isfinite(result).all():
                 return result
-
-            rstate = np.random.RandomState(seed)
-            while seed in seeds:
-                seed = rstate.randint(2 ** 32)
 
     # Python 2.7 walkarround necessary for test purposes
     if not hasattr(wrapper, '__wrapped__'):
         setattr(wrapper, '__wrapped__', f)
 
     return wrapper
+
+
+def seedSequence(seed):
+    """
+    Yields a sequence of unique, pseudorandom, deterministic seeds.
+
+    :param seed: beginning of the sequence
+    :return: seed generator
+    """
+    previous = set()
+    rstate = np.random.RandomState(seed)
+    while True:
+        yield seed
+
+        previous.add(seed)
+        rstate.seed(seed)
+        while seed in previous:
+            seed = rstate.randint(2 ** 32)
 
 
 def get_states_1D(seed, n=1):


### PR DESCRIPTION
`kcsd.validation.csd_profile.gauss_2d_large(seed=63)` does not return
NaN anymore.

`repeatUntilValid()` decorator has been defined for that purpose.

A simple test for the fix provided in the `__main__` section of the module.

Note: The issue has not been solved by fixing distribution of
the `zs` variable in order to provide backward-compatibility.