### PR TITLE
Optimized CV method (kESI's code)

### DIFF
--- a/kcsd/KCSD.py
+++ b/kcsd/KCSD.py
@@ -258,6 +258,9 @@ class KCSD(CSD):
         R : float
 
         """
+        if self.R == R:
+            return
+
         self.R = R
         self.dist_max = max(np.max(self.src_ele_dists),
                             np.max(self.src_estm_dists)) + self.R


### PR DESCRIPTION
I preserved most of the original code as a regression test.  For n=100 we have 8 (mean wall time) - 60 fold speedup (CPU time) with backward compatibility:
```python
In [53]: %timeit k100.cross_validate()                                                                                                                                                                                                                                         
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
909 ms ± 7.45 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [54]: %timeit k100.cross_validate(regression_test=True)                                                                                                                                                                                                                     
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
R, lambda : 1.0 2.6101572156825332e-12 OLD
max diff : 0.0003688931465148926
new min, old min : 0.08087466148709524 0.08084992462819085
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
R, lambda : 1.0 2.6101572156825332e-12 OLD
max diff : 0.0003688931465148926
new min, old min : 0.08087466148709524 0.08084992462819085
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
R, lambda : 1.0 2.6101572156825332e-12 OLD
max diff : 0.0003688931465148926
new min, old min : 0.08087466148709524 0.08084992462819085
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
R, lambda : 1.0 2.6101572156825332e-12 OLD
max diff : 0.0003688931465148926
new min, old min : 0.08087466148709524 0.08084992462819085
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
R, lambda : 1.0 2.6101572156825332e-12 OLD
max diff : 0.0003688931465148926
new min, old min : 0.08087466148709524 0.08084992462819085
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
R, lambda : 1.0 2.6101572156825332e-12 OLD
max diff : 0.0003688931465148926
new min, old min : 0.08087466148709524 0.08084992462819085
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
R, lambda : 1.0 2.6101572156825332e-12 OLD
max diff : 0.0003688931465148926
new min, old min : 0.08087466148709524 0.08084992462819085
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
R, lambda : 1.0 2.6101572156825332e-12 OLD
max diff : 0.0003688931465148926
new min, old min : 0.08087466148709524 0.08084992462819085
7.79 s ± 677 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


In [55]: %time k100.cross_validate(regression_test=True)                                                                                                                                                                                                                       
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
R, lambda : 1.0 2.6101572156825332e-12 OLD
max diff : 0.0003688931465148926
new min, old min : 0.08087466148709524 0.08084992462819085
CPU times: user 50 s, sys: 2.33 s, total: 52.3 s
Wall time: 6.72 s
Out[55]: (1.0, 2.6101572156825332e-12)

In [56]: %time k100.cross_validate()                                                                                                                                                                                                                                           
No lambda given, using defaults
Cross validating R (all lambda) : 1.0
R, lambda : 1.0 2.6101572156825332e-12
CPU times: user 897 ms, sys: 130 µs, total: 898 ms
Wall time: 897 ms
Out[56]: (1.0, 2.6101572156825332e-12)
```